### PR TITLE
Improve packer performance with guest_additions_mode = attach

### DIFF
--- a/pc4/vm/kali/kali.pkr.hcl
+++ b/pc4/vm/kali/kali.pkr.hcl
@@ -33,6 +33,8 @@ source "virtualbox-iso" "pc4-kali" {
   ssh_username        = "user"
   ssh_wait_timeout    = "10000s"
   vm_name             = "pc4-kali"
+  guest_additions_mode    = "attach"
+
 }
 
 build {

--- a/pc4/vm/win10/win10.pkr.hcl
+++ b/pc4/vm/win10/win10.pkr.hcl
@@ -67,6 +67,7 @@ source "virtualbox-iso" "pc4-win10" {
   winrm_timeout           = "4h"
   winrm_use_ssl           = true
   winrm_username          = "${var.winrm_username}"
+  guest_additions_mode    = "attach"
 }
 
 


### PR DESCRIPTION
Improve packer performance with guest_additions_mode = attach

This change greatly improves the performance of the Windows build by attaching the Virtual Box Guest Additions ISO to the VM rather than uploading it via WinRM. 